### PR TITLE
Prevent a warning in the example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ $ yarn add swrv
 
 ```vue
 <template>
-  <div v-if="error">failed to load</div>
-  <div v-if="!data">loading...</div>
-  <div v-else>hello {{ data.name }}</div>
+  <div>
+    <div v-if="error">failed to load</div>
+    <div v-if="!data">loading...</div>
+    <div v-else>hello {{ data.name }}</div>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
To prevent this warning: "the template root requires exactly one element".