### PR TITLE
Add fetchOnServer option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ const { data, error, isValidating, revalidate } = useSWRV(key, fetcher, options)
 - `cache` - caching instance to store response data in. See
   [src/lib/cache](src/lib/cache.ts), and [Cache](#cache) below.
 - `onError` - callback function when a request returns an error
+- `fetchOnServer = true` - enable fetch during server side rendering
 
 ## Prefetching
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface IConfig {
   ttl?: number
   revalidateOnFocus?: boolean
   revalidateDebounce?: number
-  fetchOnServer?: boolean
+  fetchOnServer?: boolean | (() => boolean)
   onError?: (
     err: Error,
     key: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface IConfig {
   ttl?: number
   revalidateOnFocus?: boolean
   revalidateDebounce?: number
+  fetchOnServer?: boolean
   onError?: (
     err: Error,
     key: string

--- a/src/use-swrv.ts
+++ b/src/use-swrv.ts
@@ -117,10 +117,14 @@ export default function useSWRV<Data = any, Error = any> (key: IKey, fn: fetcher
     ...config
   }
 
+  const fetchOnServer = isFunction(config.fetchOnServer)
+    ? config.fetchOnServer()
+    : config.fetchOnServer;
+
   const keyRef = typeof key === 'function' ? (key as any) : ref(key)
 
   let stateRef = null as { data: Data, error: Error, isValidating: boolean, revalidate: Function, key: any }
-  if (isSsrHydration && config.fetchOnServer) {
+  if (isSsrHydration && fetchOnServer) {
     // component was ssrHydrated, so make the ssr reactive as the initial data
     const swrvState = (window as any).__SWRV_STATE__ ||
       ((window as any).__NUXT__ && (window as any).__NUXT__.swrv) || []
@@ -254,7 +258,7 @@ export default function useSWRV<Data = any, Error = any> (key: IKey, fn: fetcher
     }
 
     onServerPrefetch(async () => {
-      if (config.fetchOnServer) {
+      if (fetchOnServer) {
         await revalidate()
       }
 
@@ -291,6 +295,10 @@ export default function useSWRV<Data = any, Error = any> (key: IKey, fn: fetcher
     ...toRefs(stateRef),
     revalidate
   }
+}
+
+function isFunction(value: any): value is Function {
+  return typeof value === 'function'
 }
 
 export { mutate }

--- a/src/use-swrv.ts
+++ b/src/use-swrv.ts
@@ -23,6 +23,7 @@ const defaultConfig: IConfig = {
   dedupingInterval: 2000,
   revalidateOnFocus: true,
   revalidateDebounce: 0,
+  fetchOnServer: true,
   onError: (_, __) => {}
 }
 
@@ -119,7 +120,7 @@ export default function useSWRV<Data = any, Error = any> (key: IKey, fn: fetcher
   const keyRef = typeof key === 'function' ? (key as any) : ref(key)
 
   let stateRef = null as { data: Data, error: Error, isValidating: boolean, revalidate: Function, key: any }
-  if (isSsrHydration) {
+  if (isSsrHydration && config.fetchOnServer) {
     // component was ssrHydrated, so make the ssr reactive as the initial data
     const swrvState = (window as any).__SWRV_STATE__ ||
       ((window as any).__NUXT__ && (window as any).__NUXT__.swrv) || []
@@ -253,7 +254,10 @@ export default function useSWRV<Data = any, Error = any> (key: IKey, fn: fetcher
     }
 
     onServerPrefetch(async () => {
-      await revalidate()
+      if (config.fetchOnServer) {
+        await revalidate()
+      }
+
       swrvRes.push({
         data: stateRef.data,
         error: stateRef.error,

--- a/tests/fixtures/disableFetchOnServer.js
+++ b/tests/fixtures/disableFetchOnServer.js
@@ -1,0 +1,35 @@
+import Vue from 'vue/dist/vue.runtime.common.js'
+import VueCompositionApi from '@vue/composition-api'
+import useSWRV from '../../esm'
+
+Vue.config.devtools = false
+Vue.use(VueCompositionApi)
+
+function fetcher (result) {
+  return new Promise(resolve => {
+    return setTimeout(() => {
+      resolve(result)
+    }, 100)
+  })
+}
+
+export default context => {
+  return new Promise(resolve => {
+    resolve(new Vue({
+      template: `
+        <div>
+          <div v-if="!data && !error">
+            loading data2
+          </div>
+          <div v-if="data">
+            data: {{ data }}
+          </div>
+        </div>
+      `,
+      setup () {
+        const { data, error } = useSWRV('data', () => fetcher('foo'), { fetchOnServer: false })
+        return { data, error }
+      }
+    }))
+  })
+}

--- a/tests/ssr.spec.ts
+++ b/tests/ssr.spec.ts
@@ -38,4 +38,21 @@ describe('SSR', () => {
       })
     })
   })
+
+  it("should show loading if fetch was disabled on server", async done => {
+    createRenderer("disableFetchOnServer.js", {}, renderer => {
+      renderer.renderToString({}, (err, res) => {
+        expect(err).toBeNull();
+        expect(res).toMatchInlineSnapshot(`
+          <div>
+            <div>
+              loading data2
+            </div>
+            <!---->
+          </div>
+        `);
+        done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
I don't know if you are interested on adding this feature to the library. 

There are some case where is interesting to decide what to fetch on the server

```js
setup() {
    const { data: post } = useSWRV('post1', () => fetchPostById(1));
    const { data: comments } = useSWRV(
       'post1comments', 
       () => fetchPostCommentsById(1), { fetchOnServer: false }
    );
    return { post, comments }
}
```

It is something similar to the `fetchOnServer` option on nuxt https://nuxtjs.org/api/pages-fetch/

I know this is a deviation from the original `swr` api, but I think that they already have the granular control with the `initialData` prop.