### PR TITLE
(fix) #88 always update error on revalidation

### DIFF
--- a/src/use-swrv.ts
+++ b/src/use-swrv.ts
@@ -100,9 +100,7 @@ const mutate = async <Data>(key: string, res: Promise<Data> | Data, cache = DATA
       if (typeof newData.data !== 'undefined') {
         r.data = newData.data
       }
-      if (newData.error) {
-        r.error = newData.error
-      }
+      r.error = newData.error
       r.isValidating = newData.isValidating
 
       const isLast = idx === refs.length - 1

--- a/tests/use-swrv.spec.tsx
+++ b/tests/use-swrv.spec.tsx
@@ -956,41 +956,41 @@ describe('useSWRV - error', () => {
   })
 
   it('should reset error if fetching succeeds', async done => {
-    let count = 0;
-    let revalidate;
+    let count = 0
+    let revalidate
 
     const wrapper = mount(defineComponent({
       template: `<div>count: {{ data }} {{ error }}</div>`,
-      setup() {
+      setup () {
         const { data, error, mutate } = useSWRV(
           'error-4',
           () => new Promise(
             (resolve, reject) => setTimeout(() => ++count === 2 ? reject(new Error('uh oh!')) : resolve(count), 100)
           ),
           { dedupingInterval: 0 }
-        );
-        revalidate = mutate;
-        return { data, error };
+        )
+        revalidate = mutate
+        return { data, error }
       }
     }))
-    const vm = wrapper.vm;
+    const vm = wrapper.vm
 
-    timeout(100);
-    await tick(vm, 3);
-    expect(wrapper.text()).toBe('count: 1');
+    timeout(100)
+    await tick(vm, 3)
+    expect(wrapper.text()).toBe('count: 1')
 
-    revalidate();
-    timeout(100);
-    await tick(vm, 3);
+    revalidate()
+    timeout(100)
+    await tick(vm, 3)
     // stale data sticks around even when error exists
-    expect(wrapper.text()).toBe('count: 1 "Error: uh oh!"');
+    expect(wrapper.text()).toBe('count: 1 "Error: uh oh!"')
 
-    revalidate();
-    timeout(100);
-    await tick(vm, 3);
+    revalidate()
+    timeout(100)
+    await tick(vm, 3)
     // error must be reset if fetching succeeds
-    expect(wrapper.text()).toBe('count: 3');
-    done();
+    expect(wrapper.text()).toBe('count: 3')
+    done()
   })
 })
 


### PR DESCRIPTION
This PR is supposed to fix issue #88. I think we should always update the error after fetching, let me know if you think differently.