### PR TITLE
feat(error) add fetch retries on error

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,9 @@ export interface IConfig {
   serverTTL?: number
   revalidateOnFocus?: boolean
   revalidateDebounce?: number
+  shouldRetryOnError?: boolean
+  errorRetryInterval?: number
+  errorRetryCount?: number
 }
 
 export interface IResponse<Data = any, Error = any> {
@@ -23,3 +26,8 @@ export interface IResponse<Data = any, Error = any> {
 type keyFunction = () => string | null
 
 export type IKey = keyFunction | string | null
+
+export interface revalidateOptions {
+  shouldRetryOnError?: boolean,
+  errorRetryCount?: number
+}

--- a/tests/use-swrv.spec.tsx
+++ b/tests/use-swrv.spec.tsx
@@ -990,6 +990,126 @@ describe('useSWRV - error', () => {
     expect(vm.$el.textContent).toBe('count: 3 ')
     done()
   })
+
+  it('should trigger error retry', async done => {
+    let count = 0
+
+    const vm = new Vue({
+      template: `<div>count: {{ data }}, {{ error }}</div>`,
+      setup () {
+        const { data, error } = useSWRV(
+          'error-retry-1',
+          () => new Promise((resolve, reject) => setTimeout(() => {
+            ++count <= 2 ? reject(new Error(`${count}`)) : resolve(count)
+          }, 100)),
+          {
+            dedupingInterval: 0,
+            errorRetryInterval: 500
+          }
+        )
+        return { data, error }
+      }
+    }).$mount()
+
+    expect(vm.$el.textContent.trim()).toBe('count: ,')
+
+    timeout(100)
+    await tick(vm, 2)
+    expect(vm.$el.textContent.trim()).toBe('count: , Error: 1')
+
+    timeout(600)
+    await tick(vm, 2)
+    expect(vm.$el.textContent).toBe('count: , Error: 2')
+
+    timeout(900)
+    await tick(vm, 2)
+    expect(vm.$el.textContent).toBe('count: , Error: 2')
+
+    timeout(200)
+    await tick(vm, 2)
+    expect(vm.$el.textContent.trim()).toBe('count: 3,')
+    done()
+  })
+
+  it('should trigger error retry and stop at count max', async done => {
+    let count = 0
+
+    const vm = new Vue({
+      template: `<div>count: {{ data }}, {{ error }}</div>`,
+      setup () {
+        const { data, error } = useSWRV(
+          'error-retry-2',
+          () => new Promise((resolve, reject) => setTimeout(() => {
+            ++count <= 6 ? reject(new Error(`${count}`)) : resolve(count)
+          }, 100)),
+          {
+            dedupingInterval: 0,
+            errorRetryInterval: 500,
+            errorRetryCount: 3
+          }
+        )
+        return { data, error }
+      }
+    }).$mount()
+
+    expect(vm.$el.textContent.trim()).toBe('count: ,')
+
+    timeout(100)
+    await tick(vm, 2)
+    expect(vm.$el.textContent.trim()).toBe('count: , Error: 1')
+
+    timeout(600)
+    await tick(vm, 2)
+    expect(vm.$el.textContent).toBe('count: , Error: 2')
+
+    timeout(1100)
+    await tick(vm, 2)
+    expect(vm.$el.textContent).toBe('count: , Error: 3')
+
+    timeout(1600)
+    await tick(vm, 2)
+    expect(vm.$el.textContent.trim()).toBe('count: , Error: 4')
+
+    timeout(2100)
+    await tick(vm, 2)
+    expect(vm.$el.textContent.trim()).toBe('count: , Error: 4') // Does not exceed retry count
+
+    done()
+  })
+
+  it('should respect disabled error retry', async done => {
+    let count = 0
+
+    const vm = new Vue({
+      template: `<div>count: {{ data }}, {{ error }}</div>`,
+      setup () {
+        const { data, error } = useSWRV(
+          'error-retry-3',
+          () => new Promise((resolve, reject) => setTimeout(() => {
+            ++count <= 3 ? reject(new Error(`${count}`)) : resolve(count)
+          }, 100)),
+          {
+            dedupingInterval: 0,
+            shouldRetryOnError: false,
+            errorRetryInterval: 500
+          }
+        )
+        return { data, error }
+      }
+    }).$mount()
+
+    expect(vm.$el.textContent.trim()).toBe('count: ,')
+
+    timeout(100)
+    await tick(vm, 2)
+    expect(vm.$el.textContent.trim()).toBe('count: , Error: 1')
+
+    timeout(600)
+    await tick(vm, 2)
+    expect(vm.$el.textContent).toBe('count: , Error: 1')
+
+    done()
+  })
 })
 
 describe('useSWRV - window events', () => {


### PR DESCRIPTION
Went with the easiest exponential backoff implementation so it's easier to test / reason about: increasing the retry based on the current retry count * retry interval

example timeline:
```
dedupingInterval: 0,
errorRetryInterval: 5000,
errorRetryCount: 3

useSwrv('user', fetch) // fails
wait 5000
fetch() ... fails
wait 10000
fetch() ... fails
wait 15000
fetch() ... fails
wait 20000
max reached, don't fetch
```

Fixes #53