### PR TITLE
test(compat) add 1.x compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "esm/**"
   ],
   "peerDependencies": {
-    "@vue/composition-api": "^0.5.0"
+    "@vue/composition-api": "^1.0.0-beta.17"
   },
   "devDependencies": {
     "@types/jest": "^24.0.19",
@@ -30,7 +30,7 @@
     "@vue/cli-plugin-typescript": "^4.4.4",
     "@vue/cli-plugin-unit-jest": "^4.4.4",
     "@vue/cli-service": "^4.4.4",
-    "@vue/composition-api": "~0.6.0",
+    "@vue/composition-api": "~1.0.0-beta.17",
     "@vue/eslint-config-standard": "^4.0.0",
     "@vue/eslint-config-typescript": "^4.0.0",
     "@vue/test-utils": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "esm/**"
   ],
   "peerDependencies": {
-    "@vue/composition-api": "^1.0.0-beta.17"
+    "@vue/composition-api": "^0.5.0 || ^1.0.0-beta.17"
   },
   "devDependencies": {
     "@types/jest": "^24.0.19",

--- a/tests/test-compat-all.sh
+++ b/tests/test-compat-all.sh
@@ -4,3 +4,4 @@ set -e
 
 tests/test-compat.sh "~0.5.0"
 tests/test-compat.sh "~0.6.0"
+tests/test-compat.sh "~1.0.0-beta.17"

--- a/tests/use-swrv.spec.tsx
+++ b/tests/use-swrv.spec.tsx
@@ -623,17 +623,15 @@ describe('useSWRV - loading', () => {
 
   it('should return loading state via undefined data', async done => {
     let renderCount = 0
-    const vm = new Vue({
-      render: h => h(defineComponent({
-        setup () {
-          const { data } = useSWRV('is-validating-1', loadData)
-          return () => {
-            renderCount++
-            return <div>hello, {!data.value ? 'loading' : data.value}</div>
-          }
-        }
-      }))
-    }).$mount()
+    const vm = new Vue(defineComponent({
+      render (h) {
+        renderCount++
+        return h('div', `hello, ${!this.data ? 'loading' : this.data}`)
+      },
+      setup () {
+        return useSWRV('is-validating-1', loadData)
+      }
+    })).$mount()
 
     expect(renderCount).toEqual(1)
     expect(vm.$el.textContent).toBe('hello, loading')
@@ -647,18 +645,15 @@ describe('useSWRV - loading', () => {
   })
 
   it('should return loading state via isValidating', async done => {
-    const vm = new Vue({
-      render: h => h(defineComponent({
-        setup () {
-          const { data, isValidating } = useSWRV('is-validating-2', loadData, {
-            refreshInterval: 1000,
-            dedupingInterval: 0
-          })
-
-          return () => <div>hello, {data.value}, {isValidating.value ? 'loading' : 'ready'}</div>
-        }
-      }))
-    }).$mount()
+    const vm = new Vue(defineComponent({
+      template: `<div>hello, {{this.data}}, {{this.isValidating ? 'loading' : 'ready'}}</div>`,
+      setup () {
+        return useSWRV('is-validating-2', loadData, {
+          refreshInterval: 1000,
+          dedupingInterval: 0
+        })
+      }
+    })).$mount()
 
     expect(vm.$el.textContent).toBe('hello, , loading')
 
@@ -682,6 +677,9 @@ describe('useSWRV - mutate', () => {
     mutate('is-prefetched-1', loadData('is-prefetched-1')).then(() => {
       const vm = new Vue({
         render: h => h(defineComponent({
+          render (h) {
+            return h('div', `hello, ${this.msg1} and ${this.msg2}`)
+          },
           setup () {
             const { data: dataFromCache } = useSWRV('is-prefetched-1', loadData)
             const { data: dataNotFromCache } = useSWRV('is-prefetched-2', loadData)
@@ -689,7 +687,7 @@ describe('useSWRV - mutate', () => {
             const msg1 = !dataFromCache.value ? 'loading' : dataFromCache.value
             const msg2 = !dataNotFromCache.value ? 'loading' : dataNotFromCache.value
 
-            return () => <div>hello, {msg1} and {msg2}</div>
+            return { msg1, msg2 }
           }
         }))
       }).$mount()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1660,12 +1660,12 @@
   optionalDependencies:
     prettier "^1.18.2"
 
-"@vue/composition-api@~0.6.0":
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.6.5.tgz#890b4ab3777ee95c6d633872db2bf53a45446d5b"
-  integrity sha512-IRdtn6/59yPNmvzlu5JTAR3SK0kK5T69wtz8oefSY8FFUPoOe7A2BlcVCypRX7jTmpBADhrHkAiklc8ffmPOuQ==
+"@vue/composition-api@~1.0.0-beta.17":
+  version "1.0.0-beta.17"
+  resolved "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.0.0-beta.17.tgz#63b65b3ed7cab649c53e4459fb0c5d3d1c545a96"
+  integrity sha512-TXa3162xQXeEoT8ar2aLPdSVGUy4phD8b3bytRORJQMvplQxi++QKXKAgYUTH0lwP0t0Dw2ddWtIyTTrOhta5w==
   dependencies:
-    tslib "^2.0.0"
+    tslib "^2.0.1"
 
 "@vue/eslint-config-standard@^4.0.0":
   version "4.0.0"
@@ -9978,10 +9978,10 @@ tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tslib@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
-  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
+tslib@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tslint@^5.20.1:
   version "5.20.1"


### PR DESCRIPTION
Adds `@vue/composition-api: "~1.0.0-beta.17"` to the compat test suite.

Related: #74 