### PR TITLE
fix: add missing dependency tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "dist/**",
     "esm/**"
   ],
+  "dependencies": {
+    "tslib": "^2.0.1"
+  },
   "peerDependencies": {
     "@vue/composition-api": "^0.5.0 || ^1.0.0-beta.17"
   },


### PR DESCRIPTION
**What's the problem this PR addresses?**

https://github.com/Kong/swrv/commit/ce75e60416d7c9c368bc36d54df9a488c40739fb changed the build target which made typescript output imports to `tslib` but it isn't declared as a dependency

**How did you fix it?**

Add `tslib` as a dependency