### PR TITLE
fix(cache/localStorage) remove encoding, fix TypeError

### DIFF
--- a/src/cache/adapters/localStorage.ts
+++ b/src/cache/adapters/localStorage.ts
@@ -12,14 +12,14 @@ export default class LocalStorageCache extends SWRVCache<any> {
     this.STORAGE_KEY = key
   }
 
-  private encode (storage) { return btoa(JSON.stringify(storage)) }
-  private decode (storage) { return JSON.parse(atob(storage)) }
+  private encode (storage) { return JSON.stringify(storage) }
+  private decode (storage) { return JSON.parse(storage) }
 
   get (k) {
     const item = localStorage.getItem(this.STORAGE_KEY)
     if (item) {
       const _key = this.serializeKey(k)
-      const itemParsed: ICacheItem<any> = JSON.parse(atob(item))[_key]
+      const itemParsed: ICacheItem<any> = JSON.parse(item)[_key]
 
       if (itemParsed.expiresAt === null) {
         itemParsed.expiresAt = Infinity // localStorage sets Infinity to 'null'

--- a/src/cache/adapters/localStorage.ts
+++ b/src/cache/adapters/localStorage.ts
@@ -21,7 +21,7 @@ export default class LocalStorageCache extends SWRVCache<any> {
       const _key = this.serializeKey(k)
       const itemParsed: ICacheItem<any> = JSON.parse(item)[_key]
 
-      if (itemParsed.expiresAt === null) {
+      if (itemParsed?.expiresAt === null) {
         itemParsed.expiresAt = Infinity // localStorage sets Infinity to 'null'
       }
 

--- a/tests/cache.spec.tsx
+++ b/tests/cache.spec.tsx
@@ -35,7 +35,7 @@ describe('cache - adapters', () => {
 
       await timeout(100)
 
-      const localStorageData: Record<string, ICacheItem<any>> = JSON.parse(atob(localStorage.getItem('swrv')))
+      const localStorageData: Record<string, ICacheItem<any>> = JSON.parse(localStorage.getItem('swrv'))
 
       expect(localStorage.getItem('swrv')).toBeDefined()
       expect(localStorageData).toHaveProperty('/api/users')
@@ -59,7 +59,7 @@ describe('cache - adapters', () => {
 
       expect(localStorage.getItem('swrv')).toBeDefined()
       const checkStorage = (key): Record<string, ICacheItem<any>> => {
-        return JSON.parse(atob(localStorage.getItem('swrv')))[key]
+        return JSON.parse(localStorage.getItem('swrv'))[key]
       }
 
       await timeout(100)
@@ -92,7 +92,7 @@ describe('cache - adapters', () => {
         if (!db) {
           return undefined
         }
-        return JSON.parse(atob(db))[key]
+        return JSON.parse(db)[key]
       }
 
       await timeout(100)


### PR DESCRIPTION
Fixes `TypeError: Cannot read property 'expiresAt' of undefined` and removes encoding so that localStorage can include utf string.