### PR TITLE
docs(example): fix "Dependent Fetching" code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ export default {
 
   setup() {
     const { data: user } = useSWRV('/api/user', fetch)
-    const { data: projects } = useSWRV(() => user.value.id && '/api/projects?uid=' + user.value.id, fetch)
+    const { data: projects } = useSWRV(() => user.value && '/api/projects?uid=' + user.value.id, fetch)
     // if the return value of the cache key function is falsy, the fetcher
     // will not trigger, but since `user` is inside the cache key function,
     // it is being watched so when it is available, then the projects will

--- a/docs/features.md
+++ b/docs/features.md
@@ -45,7 +45,7 @@ export default {
 
   setup() {
     const { data: user } = useSWRV('/api/user', fetch)
-    const { data: projects } = useSWRV(() => user.value.id && '/api/projects?uid=' + user.value.id, fetch)
+    const { data: projects } = useSWRV(() => user.value && '/api/projects?uid=' + user.value.id, fetch)
     // if the return value of the cache key function is falsy, the fetcher
     // will not trigger, but since `user` is inside the cache key function,
     // it is being watched so when it is available, then the projects will


### PR DESCRIPTION
In example:

```js
const { data: projects } = useSWRV(() => user.value.id && '/api/projects?uid=' + user.value.id, fetch)
```

Accessing `user.value.id` would probably fail because `user.value` might be `undefined`...? We could also make this `user.value?.id` but I went with shorter code 😎 👇 

```js
const { data: projects } = useSWRV(() => user.value && '/api/projects?uid=' + user.value.id, fetch)
```