### PR TITLE
Add undefined to IKey type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface IResponse<Data = any, Error = any> {
   mutate: (data?: fetcherFn<Data>, opts?: revalidateOptions) => Promise<void>
 }
 
-export type keyType = string | any[] | null
+export type keyType = string | any[] | null | undefined
 type keyFunction = () => keyType
 
 export type IKey = keyFunction | keyType


### PR DESCRIPTION
Following the docs this is now allowed in typescript since the IKey cannot be a function that returns `undefined`.

```javascript
const { data: user } = useSWRV("/api/user", fetch);
const { data: projects } = useSWRV( () => user.value.id && "/api/projects?uid=" + user.value.id, fetch);
```

Here is the typescript error:
`Argument of type '() => string | undefined' is not assignable to parameter of type 'IKey'.`

The work around would be to do something like this:
```javascript
const { data: user } = useSWRV("/api/user", fetch);
const { data: projects } = useSWRV( () => (user.value.id && "/api/projects?uid=" + user.value.id)  || null, fetch);
```
