### PR TITLE
fix(isValidating): add nullish check when no key

### DIFF
--- a/src/use-swrv.ts
+++ b/src/use-swrv.ts
@@ -384,6 +384,7 @@ function useSWRV<Data = any, Error = any> (...args): IResponse<Data, Error> {
     watch(keyRef, (val) => {
       keyRef.value = val
       stateRef.key = val
+      stateRef.isValidating = Boolean(val)
       setRefCache(keyRef.value, stateRef, ttl)
 
       if (!IS_SERVER && !isHydrated && keyRef.value) {

--- a/tests/use-swrv.spec.tsx
+++ b/tests/use-swrv.spec.tsx
@@ -683,6 +683,19 @@ describe('useSWRV - loading', () => {
 
     done()
   })
+
+  // #195
+  it('should return loading state isValidating with nullish key', async done => {
+    const vm = new Vue(defineComponent({
+      template: `<div>{{ error }}:{{this.isValidating ? 'loading' : 'ready'}}</div>`,
+      setup () {
+        return useSWRV(() => null)
+      }
+    })).$mount()
+
+    expect(vm.$el.textContent).toBe(':ready')
+    done()
+  })
 })
 
 describe('useSWRV - mutate', () => {


### PR DESCRIPTION
When a swrv key changes, if the key value resolves to a falsey value, then set the `isValidating` accordingly, since a falsey key is never validating.

Fixes #195