### PR TITLE
distribute src for sourcemaps work

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**",
-    "esm/**"
+    "esm/**",
+    "src/**"
   ],
   "peerDependencies": {
     "@vue/composition-api": "^0.5.0 || ^1.0.0-beta.17 || ^1.0.0-rc.5"


### PR DESCRIPTION
Sourcemaps point to `src` which is not distributed.

```
Sourcemap for "/node_modules/swrv/esm/cache/adapters/localStorage.js" points to missing source files
Sourcemap for "/node_modules/swrv/esm/cache/index.js" points to missing source files
Sourcemap for "/node_modules/swrv/esm/index.js" points to missing source files
Sourcemap for "/node_modules/swrv/esm/lib/hash.js" points to missing source files
Sourcemap for "/node_modules/swrv/esm/use-swrv.js" points to missing source files
Sourcemap for "/node_modules/swrv/esm/lib/web-preset.js" points to missing source files
```