### PR TITLE
fix(errorRetryCount): Make sure fetcher doesn't run endlessly when errorRetryCount is set to 0

### DIFF
--- a/src/use-swrv.ts
+++ b/src/use-swrv.ts
@@ -75,7 +75,7 @@ function onErrorRetry (revalidate: (any, opts: revalidateOptions) => void, error
     return
   }
 
-  if (config.errorRetryCount && errorRetryCount > config.errorRetryCount) {
+  if (config.errorRetryCount !== undefined && errorRetryCount > config.errorRetryCount) {
     return
   }
 


### PR DESCRIPTION
The following is sample code using `vue@2.6.14` and `@vue/composition-api@1.4.5`:

```vue
<template>
  <div>{{ data }}</div>
</template>

<script lang="ts">
import { defineComponent } from '@vue/composition-api';
import useSWRV from 'swrv';

const fetcher = () => {
  console.count('fetcher');
  return Promise.reject(new Error('rejected!'));
};

export default defineComponent({
  name: 'App',
  setup() {
    const { data } = useSWRV('/api/v2/foo', fetcher, {
      errorRetryCount: 0,
    });

    return {
      data,
    };
  },
});
</script>
```

When you run the code above, you'll see the following in your browser's console:

```
fetcher: 1
fetcher: 2
fetcher: 3
fetcher: 4
fetcher: 5
fetcher: 6
fetcher: 7
fetcher: 8
fetcher: 9
fetcher: 10
fetcher: 11
fetcher: 12
fetcher: 13
fetcher: 14
fetcher: 15
fetcher: 16
fetcher: 17
fetcher: 18
fetcher: 19
fetcher: 20
...(endlessly)
```