### PR TITLE
feat: fix types aligning with doc; and support null for mutate

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export interface IConfig<
   shouldRetryOnError?: boolean
   errorRetryInterval?: number
   errorRetryCount?: number
-  fetcher?: Fn,
+  fetcher?: Fn | null,
   isOnline?: () => boolean
   isDocumentVisible?: () => boolean
 }
@@ -27,7 +27,7 @@ export interface IResponse<Data = any, Error = any> {
   data: Ref<Data | undefined>
   error: Ref<Error | undefined>
   isValidating: Ref<boolean>
-  mutate: (data?: fetcherFn<Data>, opts?: revalidateOptions) => Promise<void>
+  mutate: (data?: fetcherFn<Data> | null, opts?: revalidateOptions) => Promise<void>
 }
 
 export type keyType = string | any[] | null | undefined

--- a/src/use-swrv.ts
+++ b/src/use-swrv.ts
@@ -146,12 +146,12 @@ function useSWRV<Data = any, Error = any>(
 ): IResponse<Data, Error>
 function useSWRV<Data = any, Error = any>(
   key: IKey,
-  fn?: fetcherFn<Data>,
+  fn?: fetcherFn<Data> | null,
   config?: IConfig
 ): IResponse<Data, Error>
 function useSWRV<Data = any, Error = any> (...args): IResponse<Data, Error> {
   let key: IKey
-  let fn: fetcherFn<Data> | undefined
+  let fn: fetcherFn<Data> | undefined | null
   let config: IConfig = { ...defaultConfig }
   let unmounted = false
   let isHydrated = false
@@ -221,7 +221,7 @@ function useSWRV<Data = any, Error = any> (...args): IResponse<Data, Error> {
   /**
    * Revalidate the cache, mutate data
    */
-  const revalidate = async (data?: fetcherFn<Data>, opts?: revalidateOptions) => {
+  const revalidate = async (data?: fetcherFn<Data> | null, opts?: revalidateOptions) => {
     const isFirstFetch = stateRef.data === undefined
     const keyVal = keyRef.value
     if (!keyVal) { return }
@@ -235,7 +235,7 @@ function useSWRV<Data = any, Error = any> (...args): IResponse<Data, Error> {
       stateRef.error = newData.error
     }
 
-    const fetcher = data || fn
+    const fetcher = typeof data === 'undefined' ? fn : data
     if (
       !fetcher ||
       (!config.isDocumentVisible() && !isFirstFetch) ||


### PR DESCRIPTION
Doc says

> If null, swrv will fetch from cache only and not revalidate.

But type doesn't accept `null` as fetcher. resolves https://github.com/Kong/swrv/issues/148

In addition, `mutate` (internally `revalidate`) does not treat `null` as special value differing to `undefined`. This changes runtime behavior a little. Now we can override `mutate` fetcher function with `null` even if initial fetcher function is not `null`. `undefined` stays as falling back to initial fetcher.