### PR TITLE
fix(use-swrv): do not await set timeout to execute

### DIFF
--- a/src/use-swrv.ts
+++ b/src/use-swrv.ts
@@ -288,7 +288,7 @@ function useSWRV<Data = any, Error = any> (...args): IResponse<Data, Error> {
     }
 
     if (newData && config.revalidateDebounce) {
-      await setTimeout(async () => {
+      setTimeout(async () => {
         if (!unmounted) {
           await trigger()
         }


### PR DESCRIPTION
Removing unneeded await from setTimeout call. Resolves #323.