### PR TITLE
feat(use-swrv): reactive refreshInterval

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,11 +4,13 @@ import LocalStorageCache from './cache/adapters/localStorage'
 
 export type fetcherFn<Data> = (...args: any) => Data | Promise<Data>
 
+type MaybeRef<T> = T | Ref<T>
+
 export interface IConfig<
   Data = any,
   Fn extends fetcherFn<Data> = fetcherFn<Data>
 > {
-  refreshInterval?: number
+  refreshInterval?: MaybeRef<number>
   cache?: LocalStorageCache | SWRVCache<any>
   dedupingInterval?: number
   ttl?: number

--- a/tests/use-swrv.spec.tsx
+++ b/tests/use-swrv.spec.tsx
@@ -971,6 +971,70 @@ describe('useSWRV - refresh', () => {
     expect(wrapper.text()).toEqual('count: 2')
   })
 
+  it('should stop rerendering when interval is changed to zero', async () => {
+    let count = 0
+
+    const refreshInterval = ref(200)
+
+    const wrapper = mount(defineComponent({
+      template: '<div>count: {{ data }}</div>',
+      setup () {
+        return useSWRV('dynamic-1-1', () => count++, {
+          refreshInterval,
+          dedupingInterval: 0
+        })
+      }
+    }))
+
+    await tick(2)
+    expect(wrapper.text()).toEqual('count: 0')
+    timeout(210)
+    await tick(2)
+    expect(wrapper.text()).toEqual('count: 1')
+    refreshInterval.value = 0
+    timeout(210)
+    await tick(2)
+    expect(wrapper.text()).toEqual('count: 2')
+    timeout(210)
+    await tick(2)
+    expect(wrapper.text()).toEqual('count: 2')
+  })
+
+  it('should start rerendering when interval is changed from zero to non-zero', async () => {
+    let count = 0
+
+    const refreshInterval = ref(0)
+
+    const wrapper = mount(defineComponent({
+      template: '<div>count: {{ data }}</div>',
+      setup () {
+        return useSWRV('dynamic-1-2', () => count++, {
+          refreshInterval,
+          dedupingInterval: 0
+        })
+      }
+    }))
+
+    await tick(2)
+    expect(wrapper.text()).toEqual('count: 0')
+    timeout(200)
+    await tick(2)
+    expect(wrapper.text()).toEqual('count: 0')
+    refreshInterval.value = 200
+    timeout(200)
+    await tick(2)
+    expect(wrapper.text()).toEqual('count: 0')
+    timeout(210)
+    await tick(2)
+    expect(wrapper.text()).toEqual('count: 1')
+    timeout(210)
+    await tick(2)
+    expect(wrapper.text()).toEqual('count: 2')
+    timeout(210)
+    await tick(2)
+    expect(wrapper.text()).toEqual('count: 3')
+  })
+
   it('should dedupe requests combined with intervals - promises', async () => {
     advanceTo(new Date())
     /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "outDir": "./dist",
     "types": [
       "webpack-env",
-      "node", "jest"
+      "node", 
+      "jest"
     ],
     "lib": [
       "esnext",


### PR DESCRIPTION
## Description
The reactive `refreshInterval` is useful when you want to stop or start polling.

example: if you have a dropdown component, the content part is showing data from a polling request, to avoid sending unnecessary requests, you may want to start the polling when the dropdown is opened and stop the polling when the dropdown is closed.