### PR TITLE
feat(ci): add timeout-minutes to ci jobs [KHCP-8104]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     name: Build and Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         node-version: [16.x]


### PR DESCRIPTION
Adds `timeout-minutes` to CI jobs to prevent jobs from running too long