### PR TITLE
feat: Add cache to IndexedDB

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -274,6 +274,32 @@ function useTodos () {
 }
 ```
 
+### indexedDB
+
+Here is another use case that supports `indexedDB`.
+
+* The storage capacity is much larger than that of local storage.
+* Support complex data structures.
+* asynchronous operation
+* Index and query capabilities
+
+```ts
+import useSWRV from 'swrv'
+import IndexedDBStoargeCache from 'swrv/dist/cache/adapters/indexedDBStoarge'
+
+function useTodos () {
+  const { data, error } = useSWRV('/todos', undefined, {
+    cache: new IndexedDBStoargeCache(),
+    shouldRetryOnError: false
+  })
+
+  return {
+    data,
+    error
+  }
+}
+```
+
 ### Serve from cache only
 
 To only retrieve a swrv cache response without revalidating, you can set the fetcher function to `null` from the useSWRV call. This can be useful when there is some higher level swrv composable that is always sending data to other instances, so you can assume that composables with a `null` fetcher will have data available. This [isn't very intuitive](https://github.com/Kong/swrv/issues/148), so will be looking for ways to improve this api in the future.

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,6 @@ module.exports = {
   preset: '@vue/cli-plugin-unit-jest/presets/typescript-and-babel',
   testMatch: [
     '<rootDir>/tests/**/*.spec.[jt]s?(x)'
-  ]
+  ],
+  setupFiles: ['fake-indexeddb/auto']
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-vue": "^8.7.1",
+    "fake-indexeddb": "4.0.2",
     "file-loader": "^5.0.2",
     "jest": "^27.1.0",
     "jest-date-mock": "^1.0.8",
@@ -62,5 +63,8 @@
   "types": "./dist/index.d.ts",
   "volta": {
     "node": "16.16.0"
+  },
+  "dependencies": {
+    "idb-keyval": "^6.2.1"
   }
 }

--- a/src/cache/adapters/indexedDBStoarge.ts
+++ b/src/cache/adapters/indexedDBStoarge.ts
@@ -1,0 +1,81 @@
+import SWRVCache, { ICacheItem } from '..'
+import { get, set, createStore, del } from 'idb-keyval'
+// why use idb-keyval
+// This is a super-simple promise-based keyval store implemented with IndexedDB, originally based on async-storage by Mozilla.
+// It's small and tree-shakeable. If you only use get/set, the library is ~250 bytes (brotli'd), if you use all methods it's ~534 bytes.
+// localForage offers similar functionality, but supports older browsers with broken/absent IDB implementations. Because of that, it's orders of magnitude bigger (~7k).
+// This is only a keyval store. If you need to do more complex things like iteration & indexing, check out IDB on NPM (a little heavier at 1k). The first example in its README is how to create a keyval store.
+// star num is 750,457 / week
+/**
+ * IndexedDB cache adapter for swrv data cache.
+ * https://developer.mozilla.org/zh-CN/docs/Web/API/Window/indexedDB
+ */
+
+export default class IndexedDBStoargeCache extends SWRVCache<any> {
+  protected db = null;
+  protected storeName = 'swrv-store';
+  protected tableName = 'swrv';
+  protected store = null;
+
+  // 默认存储桶: keyval-store, table:keyval
+  constructor (ttl = 0, tableName = 'swrv', storeName = 'swrv-store') {
+    super(ttl)
+    this.db = null
+    this.tableName = tableName
+    this.storeName = storeName
+    this.store = createStore(tableName, storeName)
+  }
+
+  private encode (storage) {
+    return JSON.stringify(storage)
+  }
+
+  private decode (storage) {
+    return JSON.parse(storage)
+  }
+
+  get (k: string) {
+    const _key = this.serializeKey(k)
+    const result = get(_key, this.store).then((item) => {
+      if (item) {
+        const itemParsed: ICacheItem<any> = this.decode(item)
+        if (itemParsed?.expiresAt === null) {
+          itemParsed.expiresAt = Infinity // localStorage sets Infinity to 'null'
+        }
+
+        return itemParsed
+      }
+      return undefined
+    }).catch((error) => {
+      console.error(error)
+    }) as unknown as ICacheItem<any>
+    return result
+  }
+
+  set (k: string, v: any, ttl: number) {
+    let payload = {}
+    const _key = this.serializeKey(k)
+    const timeToLive = ttl || this.ttl
+    const now = Date.now()
+    const item = {
+      data: v,
+      createdAt: now,
+      expiresAt: timeToLive ? now + timeToLive : Infinity
+    }
+    payload = item
+    this.dispatchExpire(timeToLive, item, _key)
+    set(_key, this.encode(payload), this.store)
+  }
+
+  dispatchExpire (ttl, item, serializedKey) {
+    ttl && setTimeout(() => {
+      const current = Date.now()
+      const hasExpired = current >= item.expiresAt
+      if (hasExpired) this.delete(serializedKey)
+    }, ttl)
+  }
+
+  delete (serializedKey: string) {
+    del(serializedKey, this.store).then(async () => {})
+  }
+}

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -26,6 +26,13 @@ function serializeKeyDefault (key: IKey): string {
   return key
 }
 
+export interface ISWRVCache<Data = any> {
+  get: (key: string) => ICacheItem<Data> | Promise<ICacheItem<Data>>
+  set: (key: string, value: Data, ttl?: number) => void
+  delete: (key: string) => void
+  serializeKey?: (key: string) => string
+}
+
 export default class SWRVCache<CacheData> {
   protected ttl: number
   private items?: Map<string, ICacheItem<CacheData>>
@@ -45,6 +52,7 @@ export default class SWRVCache<CacheData> {
   }
 
   set (k: string, v: any, ttl: number) {
+    // console.info('set', this.items, v, k)
     const _key = this.serializeKey(k)
     const timeToLive = ttl || this.ttl
     const now = Date.now()

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { Ref, WatchSource } from 'vue'
 import SWRVCache from './cache'
 import LocalStorageCache from './cache/adapters/localStorage'
+import IndexedDBStoargeCache from './cache/adapters/indexedDBStoarge'
 
 export type fetcherFn<Data> = (...args: any) => Data | Promise<Data>
 
@@ -9,7 +10,7 @@ export interface IConfig<
   Fn extends fetcherFn<Data> = fetcherFn<Data>
 > {
   refreshInterval?: number
-  cache?: LocalStorageCache | SWRVCache<any>
+  cache?: LocalStorageCache | IndexedDBStoargeCache | SWRVCache<any>
   dedupingInterval?: number
   ttl?: number
   serverTTL?: number

--- a/src/use-swrv.ts
+++ b/src/use-swrv.ts
@@ -266,7 +266,8 @@ function useSWRV<Data = any, Error = any> (...args): IResponse<Data, Error> {
     }
 
     // Dedupe items that were created in the last interval #76
-    if (cacheItem) {
+
+    if (cacheItem && !isPromise(cacheItem)) {
       const shouldRevalidate = Boolean(
         ((Date.now() - cacheItem.createdAt) >= config.dedupingInterval) || opts?.forceRevalidate
       )

--- a/tests/indexedDB-cache.spec.tsx
+++ b/tests/indexedDB-cache.spec.tsx
@@ -1,0 +1,147 @@
+import 'fake-indexeddb/auto'
+import { defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+import timeout from './utils/jest-timeout'
+import useSWRV from '../src/use-swrv'
+import IndexedDBStoargeCache from '../src/cache/adapters/indexedDBStoarge'
+import { createStore, get, keys, clear } from 'idb-keyval'
+import { ICacheItem } from 'src/cache'
+import { advanceBy, advanceTo } from 'jest-date-mock'
+import tick from './utils/tick'
+
+const store = createStore('swrv', 'swrv-store')
+const newStore = createStore('myAppData', 'swrv-store')
+
+jest.useFakeTimers()
+
+describe('indexedDB-cache - adapters', () => {
+  beforeEach(async () => {
+    // store?.clear()
+    // newStore?.clear();
+    await clear(store)
+    await clear(newStore)
+  })
+
+  describe('indexedDBStorage', () => {
+    const fetch = url => new Promise((resolve) => {
+      setTimeout(() => { resolve(`I am a response from ${url}`) }, 100)
+    })
+
+    it('saves data cache', async () => {
+      mount(defineComponent({
+        template: '<div>hello, {{ data }}</div>',
+        setup () {
+          return useSWRV('/api/users', fetch, {
+            cache: new IndexedDBStoargeCache()
+          })
+        }
+      }))
+      const temp = await get('/api/users', store)
+      expect(temp).toBeUndefined()
+
+      await timeout(100)
+
+      const indexedDBStoargeSourceData = await get('/api/users', store)
+      expect(indexedDBStoargeSourceData).toBeDefined()
+
+      const indexedDBStoargeSourceDataKeys = await keys(store)
+      const indexedDBStoargeData: Record<string, ICacheItem<any>> = JSON.parse(indexedDBStoargeSourceData)
+      expect(indexedDBStoargeSourceDataKeys).toContain('/api/users')
+      expect(indexedDBStoargeData.expiresAt).toBeNull() // Infinity shows up as 'null'
+      expect(indexedDBStoargeData.createdAt).toBeLessThanOrEqual(Date.now())
+      expect(indexedDBStoargeData.data.data).toBe('I am a response from /api/users')
+    })
+
+    it('updates data cache', async () => {
+      let count = 0
+      mount(defineComponent({
+        template: '<div>hello, {{ data }}</div>',
+        setup () {
+          return useSWRV('/api/consumers', () => ++count, {
+            cache: new IndexedDBStoargeCache(),
+            refreshInterval: 100,
+            dedupingInterval: 0
+          })
+        }
+      }))
+
+      await timeout(200)
+      await tick()
+
+      await get('/api/consumers', store)
+
+      const indexedDBStoargeSourceData = await get('/api/consumers', store)
+      expect(indexedDBStoargeSourceData).toBeDefined()
+
+      const checkStorage = async (key): Promise<Record<string, ICacheItem<any>>> => {
+        return JSON.parse(await get(key, store))
+      }
+
+      expect((await checkStorage('/api/consumers')).data.data).toBe(1)
+
+      await timeout(100)
+      await tick()
+      expect((await checkStorage('/api/consumers')).data.data).toBe(2)
+
+      await timeout(100)
+      await tick()
+      expect((await checkStorage('/api/consumers')).data.data).toBe(3)
+    })
+
+    it('deletes cache item after expiry', async () => {
+      advanceTo(new Date())
+      mount(defineComponent({
+        template: '<div>hello, {{ data }}</div>',
+        setup () {
+          return useSWRV('/api/services', fetch, {
+            cache: new IndexedDBStoargeCache(200)
+          })
+        }
+      }))
+
+      const checkStorage = async (key): Promise<Record<string, ICacheItem<any>>> => {
+        await get(key, store)
+        const db = await get(key, store)
+        if (!db) {
+          return undefined
+        }
+        return JSON.parse(db)
+      }
+
+      await timeout(100)
+      await tick(4)
+
+      expect((await checkStorage('/api/services')).data.data).toBe('I am a response from /api/services')
+
+      // TODO: not sure why only running both these methods works
+      await advanceBy(200)
+      await timeout(200)
+
+      await tick()
+      expect(await checkStorage('/api/services')).toBeUndefined()
+    })
+
+    it('accepts custom indexedDBStorage key', async () => {
+      mount(defineComponent({
+        template: '<div>hello, {{ data }}</div>',
+        setup () {
+          return useSWRV('/api/some-data', fetch, {
+            cache: new IndexedDBStoargeCache(0, 'myAppData', 'swrv-store')
+          })
+        }
+      }))
+
+      const myAppDataValue = await get('/api/some-data', newStore)
+      expect(myAppDataValue).toBeUndefined()
+
+      const swrvValue = await get('/api/some-data', store)
+      expect(swrvValue).toBeUndefined()
+
+      await timeout(100)
+      await tick()
+
+      const myAppDataValue2 = await get('/api/some-data', newStore)
+      expect(myAppDataValue2).toBeDefined()
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3242,6 +3242,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-arraybuffer-es6@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.7.0.tgz#dbe1e6c87b1bf1ca2875904461a7de40f21abc86"
+  integrity sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==
+
 base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -4546,6 +4551,13 @@ domelementtype@^2.0.1, domelementtype@^2.2.0:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
+domexception@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
+  dependencies:
+    webidl-conversions "^4.0.2"
+
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
@@ -5279,6 +5291,13 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+fake-indexeddb@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-4.0.2.tgz#e7a884158fa576e00f03e973b9874619947013e4"
+  integrity sha512-SdTwEhnakbgazc7W3WUXOJfGmhH0YfG4d+dRPOFoYDRTL6U5t8tvrmkf2W/C3W1jk2ylV7Wrnj44RASqpX/lEw==
+  dependencies:
+    realistic-structured-clone "^3.0.0"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -6021,6 +6040,11 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
+
+idb-keyval@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-6.2.1.tgz#94516d625346d16f56f3b33855da11bfded2db33"
+  integrity sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==
 
 ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
@@ -8862,6 +8886,15 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+realistic-structured-clone@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/realistic-structured-clone/-/realistic-structured-clone-3.0.0.tgz#7b518049ce2dad41ac32b421cd297075b00e3e35"
+  integrity sha512-rOjh4nuWkAqf9PWu6JVpOWD4ndI+JHfgiZeMmujYcPi+fvILUu7g6l26TC1K5aBIp34nV+jE1cDO75EKOfHC5Q==
+  dependencies:
+    domexception "^1.0.1"
+    typeson "^6.1.0"
+    typeson-registry "^1.0.0-alpha.20"
+
 regenerate-unicode-properties@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz#7c3192cab6dd24e21cb4461e5ddd7dd24fa8374c"
@@ -10173,6 +10206,20 @@ typescript@~4.5.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
+typeson-registry@^1.0.0-alpha.20:
+  version "1.0.0-alpha.39"
+  resolved "https://registry.yarnpkg.com/typeson-registry/-/typeson-registry-1.0.0-alpha.39.tgz#9e0f5aabd5eebfcffd65a796487541196f4b1211"
+  integrity sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==
+  dependencies:
+    base64-arraybuffer-es6 "^0.7.0"
+    typeson "^6.0.0"
+    whatwg-url "^8.4.0"
+
+typeson@^6.0.0, typeson@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/typeson/-/typeson-6.1.0.tgz#5b2a53705a5f58ff4d6f82f965917cabd0d7448b"
+  integrity sha512-6FTtyGr8ldU0pfbvW/eOZrEtEkczHRUtduBnA90Jh9kMPCiFNnXIon3vF41N0S4tV1HHQt4Hk1j4srpESziCaA==
+
 uglify-es@^3.3.4:
   version "3.3.9"
   resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
@@ -10565,6 +10612,11 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -10764,7 +10816,7 @@ whatwg-url@^5.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
-whatwg-url@^8.0.0, whatwg-url@^8.5.0:
+whatwg-url@^8.0.0, whatwg-url@^8.4.0, whatwg-url@^8.5.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.7.0.tgz#656a78e510ff8f3937bc0bcbe9f5c0ac35941b77"
   integrity sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==


### PR DESCRIPTION
### add indexedDB cache
https://github.com/Kong/swrv/issues/273

here is another use case that supports `indexedDB`.

* The storage capacity is much larger than that of local storage.
* Support complex data structures.
* asynchronous operation
* Index and query capabilities

```ts
import useSWRV from 'swrv'
import IndexedDBStoargeCache from 'swrv/dist/cache/adapters/indexedDBStoarge'

function useTodos () {
  const { data, error } = useSWRV('/todos', undefined, {
    cache: new IndexedDBStoargeCache(),
    shouldRetryOnError: false
  })

  return {
    data,
    error
  }
}
```
