### PR TITLE
fix(types): accept function for shouldRetryOnError

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export interface IConfig<
 }
 
 export interface revalidateOptions {
-  shouldRetryOnError?: boolean,
+  shouldRetryOnError?: boolean | ((err: any) => boolean),
   errorRetryCount?: number,
   forceRevalidate?: boolean,
 }


### PR DESCRIPTION
It would be nice to have the ability to determine if swrv should retry on an error based on the outcome of a function.

With the current typing this isn't possible, the [swr library](https://github.com/vercel/swr/blob/be1799d827b3de65decf10f9b874147dd3b7e691/src/_internal/types.ts#L120) does have this capability and I think it would be a nice addition to swrv.