### PR TITLE
fix(use-swrv): skip debounce for forced revalidation

### DIFF
--- a/src/use-swrv.ts
+++ b/src/use-swrv.ts
@@ -323,7 +323,7 @@ function useSWRV<Data = any, E = any> (...args): IResponse<Data, E> {
       }
     }
 
-    if (newData && config.revalidateDebounce) {
+    if (newData && config.revalidateDebounce && !opts?.forceRevalidate) {
       setTimeout(async () => {
         if (!unmounted) {
           await trigger()

--- a/tests/use-swrv.spec.tsx
+++ b/tests/use-swrv.spec.tsx
@@ -928,6 +928,40 @@ describe('useSWRV - mutate', () => {
     await tick(4)
     expect(wrapper.text().trim()).toBe('hello, 2')
   })
+
+  it('mutate skips revalidation debounce', async () => {
+    let count = 0
+    let revalidate
+    const wrapper = mount(defineComponent({
+      template: '<div>hello, {{data}}</div>',
+      setup () {
+        const { data, mutate } = useSWRV('mutate-skips-debounce', () => ++count, {
+          dedupingInterval: 0,
+          revalidateDebounce: 500
+        })
+
+        revalidate = mutate
+
+        return {
+          data
+        }
+      }
+    }))
+
+    await tick(2)
+    expect(wrapper.text().trim()).toBe('hello, 1')
+    expect(count).toBe(1)
+
+    revalidate()
+    await tick(2)
+    expect(wrapper.text().trim()).toBe('hello, 2')
+    expect(count).toBe(2)
+
+    timeout(500)
+    await tick(2)
+    expect(wrapper.text().trim()).toBe('hello, 2')
+    expect(count).toBe(2)
+  })
 })
 
 describe('useSWRV - listeners', () => {


### PR DESCRIPTION
## Summary
- bypass revalidateDebounce when revalidation is explicitly forced through mutate()
- keep debounced behavior for automatic cached revalidations
- add a regression test that proves mutate updates immediately and does not schedule a delayed duplicate fetch

Fixes #346.

## Validation
- yarn test use-swrv --runInBand
- yarn test --runInBand
- yarn types:check
- yarn lint --no-fix
- yarn build